### PR TITLE
adding JSON Schema validation of Graylog HTTP alerts

### DIFF
--- a/ghast/__main__.py
+++ b/ghast/__main__.py
@@ -133,7 +133,7 @@ def main(argv=sys.argv[1:]) -> int:
     if args.graylog_http_alert_schema is not None:
         with open(args.graylog_http_alert_schema) as f:
             ghast.server.GRAYLOG_HTTP_ALERT_SCHEMA = \
-                ghast.server.API.schema_model('graylog_http_alert',
+                ghast.server.API.schema_model("graylog_http_alert",
                                               json.load(f))
     ghast.server.APP.register_blueprint(
         ghast.server.API_BLUEPRINT,
@@ -147,7 +147,7 @@ def main(argv=sys.argv[1:]) -> int:
             debug=True
         )
     else:
-        path_info_dispatcher = PathInfoDispatcher({'/': ghast.server.APP})
+        path_info_dispatcher = PathInfoDispatcher({"/": ghast.server.APP})
         server = WSGIServer((args.host, args.port), path_info_dispatcher)
         try:
             server.start()

--- a/ghast/__main__.py
+++ b/ghast/__main__.py
@@ -90,7 +90,7 @@ def get_parser() -> argparse.ArgumentParser:
                             "Graylog HTTP alert callback")
     group.add_argument(
         "-f", "--alert-schema", dest="graylog_http_alert_schema", default=None,
-        help="Enable using the JSON Schema (Draft V4) at the given path to"
+        help="Enable using the JSON Schema (Draft V4) at the given path to "
              "validate incoming Graylog HTTP alerts. Graylog HTTP alerts "
              "that fail validate against the given JSON Schema will obtain "
              "a HTTP 400 Error.")

--- a/ghast/server.py
+++ b/ghast/server.py
@@ -20,6 +20,8 @@ API_BLUEPRINT = Blueprint('ghast api', __name__)
 ALERT_SCRIPT_PATH = None
 # to be set within __main__.py
 API_HTTPS = False
+# to be set within __main__.py
+GRAYLOG_HTTP_ALERT_SCHEMA = None
 
 
 class HTTPSApi(Api):
@@ -62,6 +64,7 @@ class AlertScriptTrigger(Resource):
         """Removing automatic/implicit support for GET requests"""
         API.abort(405)
 
+    @API.expect(GRAYLOG_HTTP_ALERT_SCHEMA, validate=True)
     @API.marshal_with(http_alert_script_triggered_model, code=200)
     def post(self):
         """Handle incoming Graylog HTTP alert callbacks and trigger the


### PR DESCRIPTION
Added a `--alert-schema` argument which specifies the path to a JSON Schema (Draft v4) to be used to match against incoming Graylog HTTP alert notifications.